### PR TITLE
Rebrand from nVotes to Sequent Tech

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2014-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 name: ORT licensing

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/.gitignore.license
+++ b/.gitignore.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort-data/curations-dir/bsd_license.yml
+++ b/.ort-data/curations-dir/bsd_license.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 ---

--- a/.ort-data/curations-dir/distlib.yml
+++ b/.ort-data/curations-dir/distlib.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::distlib"

--- a/.ort-data/curations-dir/drangandroptouch.yml
+++ b/.ort-data/curations-dir/drangandroptouch.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "dragandroptouch"

--- a/.ort-data/curations-dir/fractionjs.yml
+++ b/.ort-data/curations-dir/fractionjs.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::fraction.js"

--- a/.ort-data/curations-dir/java.yml
+++ b/.ort-data/curations-dir/java.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "Maven:javax.cache:cache-api"

--- a/.ort-data/curations-dir/jszip.yml
+++ b/.ort-data/curations-dir/jszip.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::jszip"

--- a/.ort-data/curations-dir/psycopg2-binary.yml
+++ b/.ort-data/curations-dir/psycopg2-binary.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::psycopg2-binary"

--- a/.ort-data/curations-dir/pycryptodomex.yml
+++ b/.ort-data/curations-dir/pycryptodomex.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::pycryptodomex"

--- a/.ort-data/curations-dir/reportlab.yml
+++ b/.ort-data/curations-dir/reportlab.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "PyPI::reportlab"

--- a/.ort-data/curations-dir/rng-js.yml
+++ b/.ort-data/curations-dir/rng-js.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 - id: "NPM::rng-js"

--- a/.ort-data/curations-dir/voting-booth.yml
+++ b/.ort-data/curations-dir/voting-booth.yml
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
-- id: "Yarn::agora-gui-booth"
+- id: "Yarn::voting-booth"
   curations:
     comment: "This package needs to be downloaded from git"
     vcs:
       type: "git"
-      url: "https://github.com/agoravoting/agora-gui-common.git"
+      url: "https://github.com/sequentech/common-ui.git"
       revision: "4.0.1"

--- a/.ort-data/disclosure_document.ftl
+++ b/.ort-data/disclosure_document.ftl
@@ -1,7 +1,7 @@
 [#--
 SPDX-FileCopyrightText: 2020 HERE Europe B.V.
 SPDX-FileCopyrightText: 2020-2021 Bosch.IO GmbH
-SPDX-FileCopyrightText: 2021 Agora Voting SL
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc
 
 SPDX-License-Identifier: AGPL-3.0-only
 --]

--- a/.ort-data/license-classifications.yml
+++ b/.ort-data/license-classifications.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 # SPDX-FileCopyrightText: 2020-2021 Bosch.IO GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort-data/rules.kts
+++ b/.ort-data/rules.kts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+ * SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
  * SPDX-FileCopyrightText: 2019 HERE Europe B.V.
  *
  * SPDX-License-Identifier: AGPL-3.0-only

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,5 +1,5 @@
 ##
-## SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+## SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 ##
 ## SPDX-License-Identifier: AGPL-3.0-only
 ##

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: election-orchestra
-Upstream-Contact: Agora Voting SL <contact@nvotes.com>
-Source: http://github.com/agoravoting/election-orchestra
+Upstream-Contact: Sequent Tech Inc <legal@sequentech.io>
+Source: http://github.com/sequentech/election-orchestra
 
 # Sample paragraph, commented out:
 #

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-Eduardo Robles Elvira <edulix AT nvotes DOT com>
-David Ruescas <david AT nvotes DOT com>
+Eduardo Robles Elvira <edulix@sequentech.io>
+David Ruescas <david@sequentech.io>
 Daniel García Moreno <danigm AT wadobo DOT com>
 Víctor Ramirez de la Corte <virako.9 AT gmail DOT com>

--- a/AUTHORS.license
+++ b/AUTHORS.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->
@@ -7,7 +7,7 @@ Election Orchestra
 ==================
 
 This software orchestrates the authorities servers to create election
-public-keys and perform the tallying using vfork.
+public-keys and perform the tallying using mixnet.
 
 Public API (Director)
 ---------------------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->
@@ -7,7 +7,7 @@ Election Orchestra
 ==================
 
 This software orchestrates the authorities servers to create election
-public-keys and perform the tallying using vfork.
+public-keys and perform the tallying using mixnet.
 
 Installation
 ============
@@ -15,7 +15,7 @@ Installation
 1. Download from the git repository if you haven't got a copy
 
 ```
-    $ git clone https://github.com/agoraciudadana/election-orchestra && cd election-orchestra
+    $ git clone https://github.com/sequentciudadana/election-orchestra && cd election-orchestra
 ```
 
 2. Install package and its dependencies
@@ -51,7 +51,7 @@ To generate a self-signed certificate you can do:
     $ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1000 -nodes
 ```
 
-You can find an example nginx configuration in https://github.com/agoraciudadana/frestq/blob/master/examples/hellossl/nginx_hellossl.conf
+You can find an example nginx configuration in https://github.com/sequentciudadana/frestq/blob/master/examples/hellossl/nginx_hellossl.conf
 
 Tutorial
 ========
@@ -133,7 +133,7 @@ To see the status of a task:
     |- frestq.virtual_empty_task.internal.frestq - parallel (4dba0478, finished)
     |  |- generate_private_info.orchestra_performer - sequential (17c80822, finished)
     |  |  |- frestq.virtual_empty_task.internal.frestq - external (86ba85d2, finished, root)
-    |  |  |- generate_private_info_vfork.orchestra_performer - sequential (b782e6a9, finished)
+    |  |  |- generate_private_info_mixnet.orchestra_performer - sequential (b782e6a9, finished)
     |  |- generate_private_info.orchestra_performer - simple (f9395f0a, finished)
     |- merge_protinfo.orchestra_director - sequential (3afddaba, executing)
     |  |- frestq.virtual_empty_task.internal.frestq - synchronized (5825a61b, executing)
@@ -180,21 +180,21 @@ POST https://127.0.0.1:5000/public_api/election
 
 # License
 
-Copyright (C) 2015 Agora Voting SL and/or its subsidiary(-ies).
-Contact: legal@agoravoting.com
+Copyright (C) 2015 Sequent Tech Inc and/or its subsidiary(-ies).
+Contact: legal@sequentech.io
 
-This file is part of the election-orchestra module of the Agora Voting project.
+This file is part of the election-orchestra module of the Sequent Tech project.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 Commercial License Usage
-Licensees holding valid commercial Agora Voting project licenses may use this
+Licensees holding valid commercial Sequent Tech project licenses may use this
 file in accordance with the commercial license agreement provided with the
 Software or, alternatively, in accordance with the terms contained in
-a written agreement between you and Agora Voting SL. For licensing terms and
-conditions and further information contact us at legal@agoravoting.com .
+a written agreement between you and Sequent Tech Inc. For licensing terms and
+conditions and further information contact us at legal@sequentech.io .
 
 GNU Affero General Public License Usage
 Alternatively, this file may be used under the terms of the GNU Affero General

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/asyncproc.py
+++ b/asyncproc.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/auth1.ini
+++ b/auth1.ini
@@ -1,6 +1,6 @@
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/auth2.ini
+++ b/auth2.ini
@@ -1,6 +1,6 @@
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/base_settings.py
+++ b/base_settings.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -47,7 +47,7 @@ QUEUES_OPTIONS = {
     'launch_task': {
         'max_threads': 1
     },
-    'vfork_queue': {
+    'mixnet_queue': {
         'max_threads': 1,
     }
 }

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only
 -->
@@ -8,7 +8,7 @@ Election Orchestra Benchmarking
 
 These scripts provide a way to run benchmarks on election orchestra to get basic
 timing and memory statistics. The data is obtained through calls to gnu time
-inserted into vfork scripts. These scripts use eotest, so that should be
+inserted into mixnet scripts. These scripts use eotest, so that should be
 working.
 
 Installation
@@ -70,7 +70,7 @@ over 100 for multicore). Refer to gnu time for for info on these values.
 Cleaning up
 ===========
 
-Bench.sh reverts changes made to vfork scripts after it is run. You can make sure this has worked
+Bench.sh reverts changes made to mixnet scripts after it is run. You can make sure this has worked
 by manually copying the bak files that hold the original scripts.
 
 The clear_disk.sh script can be used to delete files generated during tests. To avoid accidental use,

--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ##
-## SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+## SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 ##
 ## SPDX-License-Identifier: AGPL-3.0-only
 ##

--- a/bench/clear_disk.sh
+++ b/bench/clear_disk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ##
-## SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+## SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 ##
 ## SPDX-License-Identifier: AGPL-3.0-only
 ##

--- a/bench/cpu.gpi.license
+++ b/bench/cpu.gpi.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/bench/disk.gpi.license
+++ b/bench/disk.gpi.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/bench/mem.gpi.license
+++ b/bench/mem.gpi.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/bench/merge.sh
+++ b/bench/merge.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ##
-## SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+## SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 ##
 ## SPDX-License-Identifier: AGPL-3.0-only
 ##

--- a/bench/time.gpi.license
+++ b/bench/time.gpi.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned/cert.pem.license
+++ b/certs/selfsigned/cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned/key-nopass.pem.license
+++ b/certs/selfsigned/key-nopass.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned/key.pem.license
+++ b/certs/selfsigned/key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned/key_plus_cert.pem.license
+++ b/certs/selfsigned/key_plus_cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned2/cert.pem.license
+++ b/certs/selfsigned2/cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned2/key-nopass.pem.license
+++ b/certs/selfsigned2/key-nopass.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/certs/selfsigned2/key.pem.license
+++ b/certs/selfsigned2/key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/create_election/director_jobs.py
+++ b/create_election/director_jobs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -225,7 +225,7 @@ def merge_protinfo_task(task):
             subtask = SimpleTask(
                 receiver_url=authority.orchestra_url,
                 action="generate_public_key",
-                queue="vfork_queue",
+                queue="mixnet_queue",
                 data=dict(
                     session_id=session_id,
                     election_id=election_id,

--- a/create_election/performer_jobs.py
+++ b/create_election/performer_jobs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -273,19 +273,19 @@ def generate_private_info(task):
         )
         task.add(approve_task)
 
-    vfork_task = SimpleTask(
+    mixnet_task = SimpleTask(
         receiver_url=app.config.get('ROOT_URL', ''),
-        action="generate_private_info_vfork",
+        action="generate_private_info_mixnet",
         queue="orchestra_performer",
         data=dict()
     )
-    task.add(vfork_task)
+    task.add(mixnet_task)
 
-@decorators.task(action="generate_private_info_vfork", queue="orchestra_performer")
+@decorators.task(action="generate_private_info_mixnet", queue="orchestra_performer")
 @decorators.local_task
-def generate_private_info_vfork(task):
+def generate_private_info_mixnet(task):
     '''
-    After the task has been approved, execute vfork to generate the
+    After the task has been approved, execute mixnet to generate the
     private info
     '''
     # first of all, check that parent task is approved, but we only check that
@@ -335,7 +335,7 @@ def generate_private_info_vfork(task):
     # set the output data of parent task, and update sender
     task.get_parent().set_output_data(protinfos)
 
-@decorators.task(action="generate_public_key", queue="vfork_queue")
+@decorators.task(action="generate_public_key", queue="mixnet_queue")
 def generate_public_key(task):
     '''
     Generates the local private info for a new election
@@ -371,7 +371,7 @@ def generate_public_key(task):
         if "Unable to download signature!" in o or\
                 "ERROR: Invalid socket address!" in o:
             p.kill(signal.SIGKILL)
-            raise TaskError(dict(reason='error executing vfork'))
+            raise TaskError(dict(reason='error executing mixnet'))
 
     #call_cmd(["vmn", "-keygen", "publicKey_raw"], cwd=session_privpath,
     #         timeout=10*60, check_ret=0, output_filter=output_filter)
@@ -384,7 +384,7 @@ def generate_public_key(task):
         '''
         if "Failed to parse info files!" in o:
             p.kill(signal.SIGKILL)
-            raise TaskError(dict(reason='error executing vfork'))
+            raise TaskError(dict(reason='error executing mixnet'))
 
     # transform it into json format
     #call_cmd(["vmnc", "-pkey", "-outi", "json", "publicKey_raw",

--- a/demociphs.py
+++ b/demociphs.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/election-orchestra.kdev4.license
+++ b/election-orchestra.kdev4.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/models.py
+++ b/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -75,7 +75,7 @@ class Election(db.Model):
 
 class Session(db.Model):
     '''
-    Refers vfork session, with its own public key and protinfo
+    Refers mixnet session, with its own public key and protinfo
     '''
     id = db.Column(db.Unicode(255), primary_key=True)
 

--- a/public_api.py
+++ b/public_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -109,7 +109,7 @@ def post_election():
         },
         {
           "name": "Agora Ciudadana",
-          "orchestra_url": "https://agoravoting.com:6874/orchestra",
+          "orchestra_url": "https://sequentech.io:6874/orchestra",
           "ssl_cert": "-----BEGIN CERTIFICATE-----\nMIIFATCCA+mgAwIBAgIQAOli4NZQEWpKZeYX25jjwDANBgkqhkiG9w0BAQUFADBz\n8YOltJ6QfO7jNHU9jh/AxeiRf6MibZn6fvBHvFCrVBvDD43M0gdhMkVEDVNkPaak\nC7AHA/waXZ2EwW57Chr2hlZWAkwkFvsWxNt9BgJAJJt4CIVhN/iau/SaXD0l0t1N\nT0ye54QPYl38Eumvc439Yd1CeVS/HYbP0ISIfpNkkFA5TiQdoA==\n-----END CERTIFICATE-----"
         },
         {

--- a/reject_adapter.py
+++ b/reject_adapter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/agoravoting/frestq.git@master
+git+https://github.com/sequentech/frestq.git@master
 requests==2.22.0
 Flask==1.0.0
 Flask-SQLAlchemy==2.4.4

--- a/requirements.txt.license
+++ b/requirements.txt.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Agora Voting SL <contact@nvotes.com>
+SPDX-FileCopyrightText: 2021 Sequent Tech Inc <legal@sequentech.io>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/second_settings.py
+++ b/second_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -32,7 +32,7 @@ ALLOW_ONLY_SSL_CONNECTIONS = True
 AUTOACCEPT_REQUESTS = True
 
 QUEUES_OPTIONS = {
-    'vfork_queue': {
+    'mixnet_queue': {
         'max_threads': 1,
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -8,16 +8,16 @@ from setuptools import setup, find_packages
 setup(
     name='election-orchestra',
     version='master',
-    author='nVotes Team',
-    author_email='contact@nvotes.com',
+    author='Sequent Team',
+    author_email='legal@sequentech.io',
     packages=find_packages(),
     scripts=[],
-    url='http://github.com/agoravoting/election-orchestra',
+    url='http://github.com/sequentech/election-orchestra',
     license='AGPL-3.0',
     description='election orchestrator',
     long_description=open('README.md').read(),
     install_requires=[
-        'frestq @ git+https://github.com/agoravoting/frestq.git@master',
+        'frestq @ git+https://github.com/sequentech/frestq.git@master',
         'requests==2.22.0',
         'Flask==1.0.0',
         'Flask-SQLAlchemy==2.4.4',

--- a/sha256.py
+++ b/sha256.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/tally_election/director_jobs.py
+++ b/tally_election/director_jobs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -56,7 +56,7 @@ class TallyElectionTask(TaskHandler):
         self.task.add(parallel_task)
 
         # 2. once all the authorities have reviewed and accepted the tallies
-        # (one per question/session), launch vfork to perform it
+        # (one per question/session), launch mixnet to perform it
         seq_task = SequentialTask()
         self.task.add(seq_task)
         for session_id in session_ids:
@@ -66,7 +66,7 @@ class TallyElectionTask(TaskHandler):
                 auth_task = SimpleTask(
                     receiver_url=authority.orchestra_url,
                     action="perform_tally",
-                    queue="vfork_queue",
+                    queue="mixnet_queue",
                     data={
                         'election_id': data['election_id'],
                         'session_id': session_id

--- a/taskqueue.py
+++ b/taskqueue.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #

--- a/vmn.py
+++ b/vmn.py
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: 2013-2021 Agora Voting SL <contact@nvotes.com>
+# SPDX-FileCopyrightText: 2013-2021 Sequent Tech Inc <legal@sequentech.io>
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 #
@@ -8,57 +8,57 @@ from utils import *
 from frestq.app import app
 
 #
-# interface functions for vfork commands
+# interface functions for mixnet commands
 #
 
-def kill_vfork():
-    print("killing previous vfork instances..")
+def kill_mixnet():
+    print("killing previous mixnet instances..")
     devnull = open('/dev/null', 'w')
-    subprocess.call("ps aux | grep java | grep -i vfork | awk '{print $2}' | xargs kill -9",
+    subprocess.call("ps aux | grep java | grep -i mixnet | awk '{print $2}' | xargs kill -9",
       shell=True, stdout=devnull, stderr=devnull)
 
-def pre_kill_vfork(func):
+def pre_kill_mixnet(func):
     def go(*args, **kwargs):
         # TODO: add some config flag
         if(app.config.get('KILL_ALL_VFORK_BEFORE_START_NEW', False)):
-            kill_vfork()
+            kill_mixnet()
 
         return func(*args, **kwargs)
     return go
 
-@pre_kill_vfork
+@pre_kill_mixnet
 def v_gen_protocol_info(session_id, name, num_parties, num_threshold_parties, session_privpath):
     command = ["vmni", "-prot", "-sid", session_id, "-name", name, "-nopart",
         str(num_parties), "-thres", str(num_threshold_parties)]
 
     return subprocess.check_call(command, cwd=session_privpath)
 
-@pre_kill_vfork
+@pre_kill_mixnet
 def v_gen_private_info(auth_name, server_url, hint_server_url, session_privpath):
     command = ["vmni", "-party", "-arrays", "file", "-name", auth_name, "-http",
             server_url, "-hint", hint_server_url]
 
     return subprocess.check_call(command, cwd=session_privpath)
 
-@pre_kill_vfork
+@pre_kill_mixnet
 def v_merge(protinfos, session_privpath):
     start = ["vmni", "-merge"]
     command = start + protinfos
 
     return subprocess.check_call(command, cwd=session_privpath)
 
-@pre_kill_vfork
+@pre_kill_mixnet
 def v_gen_public_key(session_privpath, output_filter):
     return call_cmd(["vmn", "-keygen", "publicKey_raw"], cwd=session_privpath,
              timeout=10*60, check_ret=0, output_filter=output_filter)
 
-@pre_kill_vfork
+@pre_kill_mixnet
 def v_mix(session_privpath, output_filter=None):
     return call_cmd(["vmn", "-mix", "privInfo.xml", "protInfo.xml",
         "ciphertexts_raw", "plaintexts_raw"], cwd=session_privpath,
         timeout=5*3600, check_ret=0, output_filter=output_filter)
 
-@pre_kill_vfork
+@pre_kill_mixnet
 def v_reset(election_private_path):
     return subprocess.check_call(["vmn", "-reset", "privInfo.xml", "protInfo.xml",
       "-f"], cwd=election_private_path)


### PR DESCRIPTION
Rebrands the whole repository from nVotes to Sequent Tech, changing all references in code, documentation, comments and file names. This rebranding includes the renaming of all the repositories too.