### PR TITLE
Add keys ceremonies

### DIFF
--- a/keys_management.py
+++ b/keys_management.py
@@ -65,7 +65,7 @@ def assert_private_key_file_hashes(election_id, session_ids):
     # assert private key file  hashes
     for session_privpath in private_key_file_paths:
         if not os.path.exists(session_privpath):
-            return (f'missing file {session_privpath}', 500)
+            return (f'missing file {session_privpath}', 400)
 
         # hash session file
         session_privpath_hashfile = get_file_hash_path(session_privpath)
@@ -136,7 +136,7 @@ def delete_private_share(election_id, private_key_base64):
     # ensure all files exist or otherwise delete none
     for session_privpath in private_key_file_paths:
         if not os.path.exists(session_privpath):
-            return (f'missing file {session_privpath}', 500)
+            return (f'missing file {session_privpath}', 400)
 
     for session_privpath in private_key_file_paths:
         os.remove(session_privpath)

--- a/keys_management.py
+++ b/keys_management.py
@@ -1,0 +1,88 @@
+from frestq.app import app, db
+from models import Election
+import tempfile
+from models import Session
+import os
+import shutil
+from tools.create_tarball import hash_file, create_deterministic_tar_file
+from flask import request, make_response
+
+def get_election_by_id(election_id):
+    return db.session.query(Election)\
+        .filter(Election.id == election_id).first()
+
+def get_election_session_ids(election):
+    return [s.id for s in db.session.query(Session).\
+            with_parent(election,"sessions").\
+            order_by(Session.question_number)]
+
+def get_session_private_key_path(election_id, session_id):
+    private_data_path = app.config.get('PRIVATE_DATA_PATH', '')
+    election_private_path = os.path.join(private_data_path, str(election_id))
+    return os.path.join(election_private_path, session_id, 'privInfo.xml')
+
+def get_file_hash_path(file_path):
+    return file_path + '.sha256'
+
+def create_file_hash(file_path):
+    hashed_file_path = get_file_hash_path(file_path)
+    hash_text = hash_file(file_path, encoding = 'utf-8')
+    
+    # write the sha256 of the private key
+    with open(hashed_file_path, 'w', encoding = 'utf-8') as hashed_file:
+        hashed_file.write(hash_text)
+
+def check_file_hash(file_path):
+    hashed_file_path = get_file_hash_path(file_path)
+    hash_text = hash_file(file_path, encoding = 'utf-8')
+
+    with open(hashed_file_path, "r", encoding = 'utf-8') as hashed_file:
+        existing_hash_text = hashed_file.read()
+        return existing_hash_text == hash_text
+
+def create_tar_for_private_keys(election_id, session_ids):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        for session_id in session_ids:
+            session_privpath = get_session_private_key_path(election_id, session_id)
+            os.mkdir(os.path.join(tmpdirname, session_id), 0o755)
+            copy_privpath = os.path.join(tmpdirname, session_id, 'privInfo.xml')
+            shutil.copyfile(session_privpath, copy_privpath)
+        
+        # create and return tar file
+        with tempfile.TemporaryDirectory() as tmp_tar_folder:
+            tar_filename = "private_keys.tar.gz"
+            tar_file_path = os.path.join(tmp_tar_folder, tar_filename)
+            create_deterministic_tar_file(tar_file_path, tmpdirname)
+            return tar_file_path
+
+def download_private_share(election_id):
+    '''
+    Download private share of the keys
+    '''
+
+    if election_id is None:
+        return ("election id missing", 400)
+
+    election = get_election_by_id(election_id)
+
+    session_ids = get_election_session_ids(election)
+    private_key_file_paths = [get_session_private_key_path(election_id, session_id) for session_id in session_ids]
+
+    # assert private key file  hashes
+    for session_privpath in private_key_file_paths:
+        if not os.path.exists(session_privpath):
+            return (f'missing file {session_privpath}', 500)
+
+        # hash session file
+        session_privpath_hashfile = get_file_hash_path(session_privpath)
+        if os.path.exists(session_privpath_hashfile):
+            if not check_file_hash(session_privpath_hashfile):
+                    return (f'hash for private key file error', 500)
+        else:
+            # write the sha256 of the private key
+            create_file_hash(session_privpath_hashfile)
+    
+    # create tar file with private keys
+    tar_file_path = create_tar_for_private_keys(create_tar_for_private_keys(election_id, session_ids))
+
+    return (tar_file_path, 200)

--- a/keys_management.py
+++ b/keys_management.py
@@ -119,7 +119,7 @@ def check_private_share(election_id, private_key_base64):
             
             retcode = check_election_hashes(election_id, target_extract_folder, session_ids)
     
-    return (True == retcode, 200)
+    return (str(True == retcode), 200)
 
 def delete_private_share(election_id, private_key_base64):
     '''

--- a/public_api.py
+++ b/public_api.py
@@ -249,7 +249,8 @@ def receive_tally():
     print(request.get_json(force=True, silent=True))
     return make_response("", 202)
 
-@public_api.route('/download-private-share', methods=['POST'])
+@public_api.route('/download_private_share', methods=['POST'])
+def download_private_share():
     '''
     Download private share of the keys
     '''

--- a/public_api.py
+++ b/public_api.py
@@ -307,7 +307,7 @@ def download_private_share():
         with tempfile.TemporaryDirectory() as tmp_tar_folder:
             tar_filename = "private_keys.tar.gz"
             tar_file_path = os.path.join(tmp_tar_folder, tar_filename)
-            create_deterministic_tar_file(tmp_tar_folder, tmpdirname)
+            create_deterministic_tar_file(tar_file_path, tmpdirname)
 
             response = send_file(tar_file_path, as_attachment=True, attachment_filename=tar_filename,
                          add_etags=False, mimetype="application/gzip")

--- a/public_api.py
+++ b/public_api.py
@@ -289,7 +289,7 @@ def check_private_share():
     return make_response(result, code)
 
 @public_api.route('/delete_private_share', methods=['DELETE'])
-def check_private_share():
+def delete_private_share():
     '''
     delete private share of the keys
     '''
@@ -306,5 +306,26 @@ def check_private_share():
         make_response("private key missing", 400)
     
     result, code = keys_management.delete_private_share(election_id, private_key_base64)
+
+    return make_response(result, code)
+
+@public_api.route('/restore_private_share', methods=['DELETE'])
+def restore_private_share():
+    '''
+    restore private share of the keys
+    '''
+    print("ATTENTION received restore-private-share: ")
+
+    req = request.get_json(force=True, silent=True)
+    election_id = req.get('election_id', None)
+    private_key_base64 = req.get('private_key', None)
+
+    if not isinstance(election_id, str):
+        make_response("election id missing", 400)
+
+    if not isinstance(private_key_base64, str):
+        make_response("private key missing", 400)
+    
+    result, code = keys_management.restore_private_share(election_id, private_key_base64)
 
     return make_response(result, code)

--- a/public_api.py
+++ b/public_api.py
@@ -19,6 +19,7 @@ from frestq.app import app, db
 
 from models import Election, Authority, QueryQueue
 from create_election.performer_jobs import check_election_data
+import keys_management
 
 
 from taskqueue import queue_task, apply_task, dequeue_task
@@ -255,15 +256,14 @@ def download_private_share():
     Download private share of the keys
     '''
     print("ATTENTION received download-private-share: ")
-    from keys_management import download_private_share
 
     req = request.get_json(force=True, silent=True)
     election_id = req.get('election_id', None)
 
-    if election_id is None:
+    if not isinstance(election_id, str):
         make_response("election id missing", 400)
     
-    result, code = download_private_share(election_id)
+    result, code = keys_management.download_private_share(election_id)
 
     return make_response(result, code)
 
@@ -278,12 +278,33 @@ def check_private_share():
     election_id = req.get('election_id', None)
     private_key_base64 = req.get('private_key', None)
 
-    if election_id is None:
+    if not isinstance(election_id, str):
         make_response("election id missing", 400)
 
-    if private_key_base64 is None:
+    if not isinstance(private_key_base64, str):
         make_response("private key missing", 400)
     
-    result, code = check_private_share(election_id)
+    result, code = keys_management.check_private_share(election_id, private_key_base64)
+
+    return make_response(result, code)
+
+@public_api.route('/delete_private_share', methods=['DELETE'])
+def check_private_share():
+    '''
+    delete private share of the keys
+    '''
+    print("ATTENTION received delete-private-share: ")
+
+    req = request.get_json(force=True, silent=True)
+    election_id = req.get('election_id', None)
+    private_key_base64 = req.get('private_key', None)
+
+    if not isinstance(election_id, str):
+        make_response("election id missing", 400)
+
+    if not isinstance(private_key_base64, str):
+        make_response("private key missing", 400)
+    
+    result, code = keys_management.delete_private_share(election_id, private_key_base64)
 
     return make_response(result, code)

--- a/public_api.py
+++ b/public_api.py
@@ -265,16 +265,4 @@ def download_private_share():
     
     result, code = download_private_share(election_id)
 
-    if code != 200:
-        return make_response(result, code)
-
-    tar_file_path = result
-    response = send_file(tar_file_path, as_attachment=True, attachment_filename="private_keys.tar.gz",
-                    add_etags=False, mimetype="application/gzip")
-
-    response.headers.extend({
-        'Content-Length': os.path.getsize(tar_file_path),
-        'Cache-Control': 'no-cache'
-    })
-
-    return response
+    return make_response(result, code)

--- a/public_api.py
+++ b/public_api.py
@@ -256,7 +256,6 @@ def download_private_share():
     '''
     print("ATTENTION received download-private-share: ")
     import tempfile
-    from utils import parse_json_request
     from models import Session
     from frestq.app import db
     from flask import send_file
@@ -264,8 +263,7 @@ def download_private_share():
     import shutil
     from tools.create_tarball import hash_file, create_deterministic_tar_file
 
-    data = request.get_json(force=True, silent=True)
-    req = parse_json_request(request)
+    req = request.get_json(force=True, silent=True)
     election_id = req.get('election_id', None)
 
     if election_id is None:
@@ -282,13 +280,13 @@ def download_private_share():
     election_private_path = os.path.join(private_data_path, str(election_id))
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        for session in session_ids:
-            session_privpath = os.path.join(election_private_path, session.id, 'privInfo.xml')
+        for session_id in session_ids:
+            session_privpath = os.path.join(election_private_path, session_id, 'privInfo.xml')
             if not os.path.exists(session_privpath):
                 return make_response(f'missing file {session_privpath}', 500)
 
             # hash session file
-            session_privpath_hashfile = os.path.join(election_private_path, session.id, 'privInfo.xml.sha256')
+            session_privpath_hashfile = os.path.join(election_private_path, session_id, 'privInfo.xml.sha256')
             session_privpath_hash = hash_file(session_privpath)
             if os.path.exists(session_privpath_hashfile):
                 # check the sha256 of the private key
@@ -301,8 +299,8 @@ def download_private_share():
                 with open(session_privpath_hashfile, 'w', encoding = 'utf-8') as hash_file:
                     hash_file.write(session_privpath_hash)
 
-            os.mkdir(os.path.join(tmpdirname, session.id), 0o755)
-            copy_privpath = os.path.join(tmpdirname, session.id, 'privInfo.xml')
+            os.mkdir(os.path.join(tmpdirname, session_id), 0o755)
+            copy_privpath = os.path.join(tmpdirname, session_id, 'privInfo.xml')
             shutil.copyfile(session_privpath, copy_privpath)
         
         # create and return tar file

--- a/public_api.py
+++ b/public_api.py
@@ -255,66 +255,26 @@ def download_private_share():
     Download private share of the keys
     '''
     print("ATTENTION received download-private-share: ")
-    import tempfile
-    from models import Session
-    from frestq.app import db
-    from flask import send_file
-    import os
-    import shutil
-    from tools.create_tarball import hash_file, create_deterministic_tar_file
+    from keys_management import download_private_share
 
     req = request.get_json(force=True, silent=True)
     election_id = req.get('election_id', None)
 
     if election_id is None:
         make_response("election id missing", 400)
+    
+    result, code = download_private_share(election_id)
 
-    election = db.session.query(Election)\
-        .filter(Election.id == election_id).first()
+    if code != 200:
+        return make_response(result, code)
 
-    session_ids = [s.id for s in db.session.query(Session).\
-            with_parent(election,"sessions").\
-            order_by(Session.question_number)]
+    tar_file_path = result
+    response = send_file(tar_file_path, as_attachment=True, attachment_filename="private_keys.tar.gz",
+                    add_etags=False, mimetype="application/gzip")
 
-    private_data_path = app.config.get('PRIVATE_DATA_PATH', '')
-    election_private_path = os.path.join(private_data_path, str(election_id))
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        for session_id in session_ids:
-            session_privpath = os.path.join(election_private_path, session_id, 'privInfo.xml')
-            if not os.path.exists(session_privpath):
-                return make_response(f'missing file {session_privpath}', 500)
-
-            # hash session file
-            session_privpath_hashfile = os.path.join(election_private_path, session_id, 'privInfo.xml.sha256')
-            session_privpath_hash = hash_file(session_privpath, encoding = 'utf-8')
-            if os.path.exists(session_privpath_hashfile):
-                # check the sha256 of the private key
-                with open(session_privpath_hashfile, "r", encoding = 'utf-8') as hashed_file:
-                    hash_text = hashed_file.read()
-                    if hash_text != session_privpath_hash:
-                        return make_response(f'hash for private key file {session_privpath} error: {hash_text} != {session_privpath_hash}', 500)
-            else:
-                # write the sha256 of the private key
-                with open(session_privpath_hashfile, 'w', encoding = 'utf-8') as hashed_file:
-                    hashed_file.write(session_privpath_hash)
-
-            os.mkdir(os.path.join(tmpdirname, session_id), 0o755)
-            copy_privpath = os.path.join(tmpdirname, session_id, 'privInfo.xml')
-            shutil.copyfile(session_privpath, copy_privpath)
-        
-        # create and return tar file
-        with tempfile.TemporaryDirectory() as tmp_tar_folder:
-            tar_filename = "private_keys.tar.gz"
-            tar_file_path = os.path.join(tmp_tar_folder, tar_filename)
-            create_deterministic_tar_file(tar_file_path, tmpdirname)
-
-            response = send_file(tar_file_path, as_attachment=True, attachment_filename=tar_filename,
-                         add_etags=False, mimetype="application/gzip")
-            
-            response.headers.extend({
-                'Content-Length': os.path.getsize(tar_file_path),
-                'Cache-Control': 'no-cache'
-            })
+    response.headers.extend({
+        'Content-Length': os.path.getsize(tar_file_path),
+        'Cache-Control': 'no-cache'
+    })
 
     return response

--- a/public_api.py
+++ b/public_api.py
@@ -248,3 +248,11 @@ def receive_tally():
     print("ATTENTION received tally callback: ")
     print(request.get_json(force=True, silent=True))
     return make_response("", 202)
+
+@public_api.route('/download-private-share', methods=['POST'])
+    '''
+    Download private share of the keys
+    '''
+    print("ATTENTION received download-private-share: ")
+    data = request.get_json(force=True, silent=True)
+    return make_response(dumps(data), 200)

--- a/public_api.py
+++ b/public_api.py
@@ -287,17 +287,17 @@ def download_private_share():
 
             # hash session file
             session_privpath_hashfile = os.path.join(election_private_path, session_id, 'privInfo.xml.sha256')
-            session_privpath_hash = hash_file(session_privpath)
+            session_privpath_hash = hash_file(session_privpath, encoding = 'utf-8')
             if os.path.exists(session_privpath_hashfile):
                 # check the sha256 of the private key
-                with open("contents.txt", "r", encoding = 'utf-8') as hash_file:
-                    hash_text = hash_file.read()
+                with open(session_privpath_hashfile, "r", encoding = 'utf-8') as hashed_file:
+                    hash_text = hashed_file.read()
                     if hash_text != session_privpath_hash:
                         return make_response(f'hash for private key file {session_privpath} error: {hash_text} != {session_privpath_hash}', 500)
             else:
                 # write the sha256 of the private key
-                with open(session_privpath_hashfile, 'w', encoding = 'utf-8') as hash_file:
-                    hash_file.write(session_privpath_hash)
+                with open(session_privpath_hashfile, 'w', encoding = 'utf-8') as hashed_file:
+                    hashed_file.write(session_privpath_hash)
 
             os.mkdir(os.path.join(tmpdirname, session_id), 0o755)
             copy_privpath = os.path.join(tmpdirname, session_id, 'privInfo.xml')

--- a/public_api.py
+++ b/public_api.py
@@ -266,3 +266,24 @@ def download_private_share():
     result, code = download_private_share(election_id)
 
     return make_response(result, code)
+
+@public_api.route('/check_private_share', methods=['POST'])
+def check_private_share():
+    '''
+    Check private share of the keys
+    '''
+    print("ATTENTION received check-private-share: ")
+
+    req = request.get_json(force=True, silent=True)
+    election_id = req.get('election_id', None)
+    private_key_base64 = req.get('private_key', None)
+
+    if election_id is None:
+        make_response("election id missing", 400)
+
+    if private_key_base64 is None:
+        make_response("private key missing", 400)
+    
+    result, code = check_private_share(election_id)
+
+    return make_response(result, code)

--- a/public_api.py
+++ b/public_api.py
@@ -288,7 +288,7 @@ def check_private_share():
 
     return make_response(result, code)
 
-@public_api.route('/delete_private_share', methods=['DELETE'])
+@public_api.route('/delete_private_share', methods=['POST'])
 def delete_private_share():
     '''
     delete private share of the keys
@@ -309,7 +309,7 @@ def delete_private_share():
 
     return make_response(result, code)
 
-@public_api.route('/restore_private_share', methods=['DELETE'])
+@public_api.route('/restore_private_share', methods=['POST'])
 def restore_private_share():
     '''
     restore private share of the keys

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -35,6 +35,14 @@ BUF_SIZE = 10*1024
 # deterministic tars
 MAGIC_TIMESTAMP = 1394060400
 
+def hash_bytes(bytes):
+    '''
+    Returns the hexdigest of the hash of the bytes
+    '''
+    hash = hashlib.sha256()
+    hash.update(bytes)
+    return hash.hexdigest()
+
 def hash_file(file_path, mode = 'r', **kwargs):
     '''
     Returns the hexdigest of the hash of the contents of a file, given the file

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -222,3 +222,20 @@ def deterministic_tar_add(tfile, filepath, arcname, timestamp, uid=1000, gid=100
             newarcname = os.path.join(arcname, subitem)
             deterministic_tar_add(tfile, newpath, newarcname, timestamp, uid,
                 gid)
+
+# tarfile_path: ie /home/user/file.tar.gz
+def create_deterministic_tar_file(tarfile_path, folder_path):
+    cwd = os.getcwd()
+    try:
+        os.chdir(os.path.dirname(tarfile_path))
+        import time
+        old_time = time.time
+        time.time = lambda: MAGIC_TIMESTAMP
+        tar = tarfile.open(os.path.basename(tarfile_path), 'w|gz')
+    finally:
+        time.time = old_time
+        os.chdir(cwd)
+    timestamp = MAGIC_TIMESTAMP
+
+    deterministic_tar_add(tar, folder_path, '', timestamp)
+    tar.close()

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -35,13 +35,13 @@ BUF_SIZE = 10*1024
 # deterministic tars
 MAGIC_TIMESTAMP = 1394060400
 
-def hash_file(file_path):
+def hash_file(file_path, **kwargs):
     '''
     Returns the hexdigest of the hash of the contents of a file, given the file
     path.
     '''
     hash = hashlib.sha256()
-    f = open(file_path, 'r')
+    f = open(file_path, 'r', **kwargs)
     for chunk in f.read(BUF_SIZE):
         hash.update(chunk)
     f.close()

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -35,19 +35,20 @@ BUF_SIZE = 10*1024
 # deterministic tars
 MAGIC_TIMESTAMP = 1394060400
 
-def hash_file(file_path, **kwargs):
+def hash_file(file_path, mode = 'r', **kwargs):
     '''
     Returns the hexdigest of the hash of the contents of a file, given the file
     path.
     '''
     hash = hashlib.sha256()
-    f = open(file_path, 'r')
-    for chunk in f.read(BUF_SIZE):
-        final_chunk = chunk
-        if 'encoding' in kwargs:
-             final_chunk = chunk.encode(kwargs.get('encoding'))
-        hash.update(final_chunk)
-    f.close()
+    with open(file_path, mode) as f:
+        while True:
+            chunk = f.read(BUF_SIZE)
+            if not chunk:
+                break
+            if 'encoding' in kwargs:
+                chunk = chunk.encode(kwargs.get('encoding'))
+            hash.update(chunk)
     return hash.hexdigest()
 
 def verify_pok_plaintext(pk, proof, ciphertext):

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -251,3 +251,7 @@ def create_deterministic_tar_file(tarfile_path, folder_path):
 
     deterministic_tar_add(tar, folder_path, '', timestamp)
     tar.close()
+
+def extract_tar_file(tar_file_path, target_extract_folder):
+    with tarfile.open(tar_file_path) as tar_file:
+        tar_file.extractall(target_extract_folder)

--- a/tools/create_tarball.py
+++ b/tools/create_tarball.py
@@ -41,9 +41,12 @@ def hash_file(file_path, **kwargs):
     path.
     '''
     hash = hashlib.sha256()
-    f = open(file_path, 'r', **kwargs)
+    f = open(file_path, 'r')
     for chunk in f.read(BUF_SIZE):
-        hash.update(chunk)
+        final_chunk = chunk
+        if 'encoding' in kwargs:
+             final_chunk = chunk.encode(kwargs.get('encoding'))
+        hash.update(final_chunk)
     f.close()
     return hash.hexdigest()
 

--- a/utils.py
+++ b/utils.py
@@ -10,6 +10,7 @@ import signal
 import time
 import subprocess
 import hashlib
+import json
 
 from frestq.app import app
 from asyncproc import Process

--- a/utils.py
+++ b/utils.py
@@ -90,3 +90,9 @@ def constant_time_compare(val1, val2):
     for x, y in zip(val1, val2):
         result |= ord(x) ^ ord(y)
     return result == 0
+
+def parse_json_request(request):
+    '''
+    Returns the request body as a parsed json object
+    '''
+    return json.loads(request.body.decode('utf-8'))

--- a/utils.py
+++ b/utils.py
@@ -91,9 +91,3 @@ def constant_time_compare(val1, val2):
     for x, y in zip(val1, val2):
         result |= ord(x) ^ ord(y)
     return result == 0
-
-def parse_json_request(request):
-    '''
-    Returns the request body as a parsed json object
-    '''
-    return json.loads(request.body.decode('utf-8'))

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,6 @@ import signal
 import time
 import subprocess
 import hashlib
-import json
 
 from frestq.app import app
 from asyncproc import Process


### PR DESCRIPTION
Add endpoints to support keys ceremonies.

# Changes
* Add endpoints to download, check, delete and restore share of private keys for an election.
* A hash file is created for each of the questions, as there's a file with a private key per question. When the keys are downloaded, a tar file is created with the same structure as the files for the election that contains the private keys. Then those keys are deleted. When the keys are restored, or during the check, the hash of the deleted files is compared, using the files created previously.